### PR TITLE
0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.4
+
+## Changes
+
+* `DataCache#find` and `DataCache#query` no longer throw a KNPE when an entry was not previously registered.
+Instead, an empty query (`Query.none`) will be returned.
+
+# Version
+
+Kotlin 1.3.61 -> 1.4.10
+Gradle 5.5.1 -> 6.6.1
+
 # 0.1.3
 
 version bump to move to new repository, from now on cache will be hosted on the same repository as our other Kord projects.
@@ -12,7 +24,7 @@ repositories {
 ## Additions
 
 Added `DataCache#flow`, `DataCache#remove`, `DataCache#count` and their respective `DataEntryCache` variants 
-as utility functions.
+as utility functions.__
 
 ## Deprecations
 

--- a/annotation-processor/src/main/kotlin/com/gitlab/kordlib/cache/annotation/Property.kt
+++ b/annotation-processor/src/main/kotlin/com/gitlab/kordlib/cache/annotation/Property.kt
@@ -2,7 +2,6 @@ package com.gitlab.kordlib.cache.annotation
 
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.asTypeName
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
@@ -19,16 +18,16 @@ internal sealed class Property {
         constructor(type: TypeMirror, field: ExecutableElement) : this(type, field.simpleName.toString().removeSuffix("\$annotations")) //e.g.: id$annotations
 
 
-        override val codeBlock = CodeBlock.builder().add("%T::${property}", type).build()
+        override val codeBlock = CodeBlock.builder().add("%T::${property.removePrefix("get").decapitalize()}", type).build()
     }
 
-    data class ExtensionProperty(override  val type: TypeMirror, private val property: ExecutableElement) : Property() {
+    data class ExtensionProperty(override val type: TypeMirror, private val property: ExecutableElement) : Property() {
 
-        override val codeBlock get() = CodeBlock.builder().add("%T::${property.simpleName.toString().removeSuffix("\$annotations")}", type).build()
+        override val codeBlock get() = CodeBlock.builder().add("%T::${property.simpleName.toString().removeSuffix("\$annotations").removePrefix("get").decapitalize()}", type).build()
 
         override fun apply(spec: FileSpec.Builder, env: ProcessingEnvironment) {
             val packageElement = env.typeUtils.asElement(type).enclosingPackage
-            spec.addImport(packageElement.toString(), property.simpleName.toString().removeSuffix("\$annotations"))
+            spec.addImport(packageElement.toString(), property.simpleName.toString().removeSuffix("\$annotations").removePrefix("get").decapitalize())
         }
 
         private val Element.enclosingPackage: Element

--- a/api/src/main/kotlin/com/gitlab/kordlib/cache/api/DataCache.kt
+++ b/api/src/main/kotlin/com/gitlab/kordlib/cache/api/DataCache.kt
@@ -3,9 +3,13 @@ package com.gitlab.kordlib.cache.api
 import com.gitlab.kordlib.cache.api.data.DataDescription
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
+import mu.KLogger
+import mu.KotlinLogging
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
+
+@PublishedApi
+internal val logger = KotlinLogging.logger("DataCache")
 
 interface DataCache {
 
@@ -29,10 +33,10 @@ interface DataCache {
     /**
      * Returns a [DataEntryCache] of the given [type] if its [description][DataDescription] was registered beforehand, null otherwise.
      */
-    fun<T: Any> getEntry(type: KType) : DataEntryCache<T>?
+    fun <T : Any> getEntry(type: KType): DataEntryCache<T>?
 
     companion object {
-        private val empty = object: DataCache {
+        private val empty = object : DataCache {
             override fun <T : Any> getEntry(type: KType): DataEntryCache<T>? = DataEntryCache.none()
             override suspend fun register(description: DataDescription<out Any, out Any>) {}
         }
@@ -49,7 +53,7 @@ interface DataCache {
 /**
  * Returns a [DataEntryCache] of the given [T] if its [description][DataDescription] was registered beforehand, null otherwise.
  */
-inline fun <reified T: Any> DataCache.getEntry() : DataEntryCache<T>? = getEntry(typeOf<T>())
+inline fun <reified T : Any> DataCache.getEntry(): DataEntryCache<T>? = getEntry(typeOf<T>())
 
 /**
  * Inserts a new [item] into the cache. Inserting an entry with an id that
@@ -86,14 +90,30 @@ suspend inline fun <reified T : Any> DataCache.putAll(items: Flow<T>) = getEntry
  * Creates a new [Query] configured with the [block].
  */
 @Deprecated("use query instead", ReplaceWith("query<T>(block)"), DeprecationLevel.WARNING)
-inline fun <reified T : Any> DataCache.find(@BuilderInference block: QueryBuilder<T>.() -> Unit = {}) =
-        getEntry<T>(typeOf<T>())!!.query().apply(block).build()
+inline fun <reified T : Any> DataCache.find(@BuilderInference block: QueryBuilder<T>.() -> Unit = {}): Query<T> {
+    val entry = getEntry<T>()
+
+    if(entry == null) {
+        logger.debug { "entry cache for ${typeOf<T>()} was not registered. Consider registering the type via DataCache#register." }
+        return Query.none()
+    }
+
+    return entry.query().apply(block).build()
+}
 
 /**
  * Creates a new [Query] configured with the [block].
  */
-inline fun <reified T : Any> DataCache.query(@BuilderInference block: QueryBuilder<T>.() -> Unit = {}) =
-        getEntry<T>(typeOf<T>())!!.query().apply(block).build()
+inline fun <reified T : Any> DataCache.query(@BuilderInference block: QueryBuilder<T>.() -> Unit = {}): Query<T> {
+    val entry = getEntry<T>()
+
+    if(entry == null) {
+        logger.debug { "entry cache for ${typeOf<T>()} was not registered. Consider registering the type via DataCache#register" }
+        return Query.none()
+    }
+
+    return entry.query().apply(block).build()
+}
 
 /**
  * Removes all the values that match the [block].

--- a/api/src/test/kotlin/DataCacheTest.kt
+++ b/api/src/test/kotlin/DataCacheTest.kt
@@ -1,0 +1,30 @@
+import com.gitlab.kordlib.cache.api.DataCache
+import com.gitlab.kordlib.cache.api.DataEntryCache
+import com.gitlab.kordlib.cache.api.data.DataDescription
+import com.gitlab.kordlib.cache.api.find
+import com.gitlab.kordlib.cache.api.query
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KType
+
+class DataCacheTest {
+
+    private val nullCache = object : DataCache {
+        override fun <T : Any> getEntry(type: KType): DataEntryCache<T>? = null
+        override suspend fun register(description: DataDescription<out Any, out Any>) {}
+        override suspend fun register(descriptions: Iterable<DataDescription<out Any, out Any>>) {}
+        override suspend fun register(vararg descriptions: DataDescription<out Any, out Any>) {}
+    }
+
+    private class NotRegistered(val id: String)
+
+    @Test
+    fun `nullCache doesn't throw on getting query`(): Unit = runBlocking {
+        nullCache.query<NotRegistered> { NotRegistered::id eq "something" }.singleOrNull()
+        nullCache.find<NotRegistered> { NotRegistered::id eq "something" }.singleOrNull()
+
+        Unit
+    }
+
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '1.3.61'
+        kotlin_version = '1.4.10'
         atomicfu_version = '0.14.1'
         bintray_version = '1.8.1'
     }
@@ -22,8 +22,8 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
-    id 'org.jetbrains.kotlin.kapt' version '1.3.61'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.10'
+    id 'org.jetbrains.kotlin.kapt' version '1.4.10'
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# 0.1.4

## Changes

* `DataCache#find` and `DataCache#query` no longer throw a KNPE when an entry was not previously registered.
Instead, an empty query (`Query.none`) will be returned.

# Version

Kotlin 1.3.61 -> 1.4.10
Gradle 5.5.1 -> 6.6.1
