### PR TITLE
Dependency Upgrades

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,13 @@ kotlin {
     }
 }
 
+dependencies {
+    dokka(projects.api)
+    dokka(projects.caffeine)
+    dokka(projects.map)
+    dokka(projects.redis)
+}
+
 allOpen {
     // Required by JMH
     annotation("org.openjdk.jmh.annotations.State")

--- a/buildSrc/src/main/kotlin/Documentation.kt
+++ b/buildSrc/src/main/kotlin/Documentation.kt
@@ -1,13 +1,15 @@
+import org.gradle.api.Project
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.gradle.kotlin.dsl.*
+import org.jetbrains.dokka.gradle.DokkaExtension
 
-fun DokkaTask.configure(additional: DokkaTask.() -> Unit = {}) {
-    this.outputDirectory.set(project.file("${project.projectDir}/dokka/kord/"))
+fun DokkaExtension.configure(project: Project, additional: DokkaExtension.() -> Unit = {}) {
+    this.dokkaPublicationDirectory.set(project.file("${project.projectDir}/dokka/kord/"))
 
     dokkaSourceSets.configureEach {
         sourceLink {
             localDirectory = project.file("src/main/kotlin")
-            remoteUrl = project.uri("https://github.com/kordlib/kord/tree/master/${project.name}/src/$name/kotlin/").toURL()
+            remoteUrl = project.uri("https://github.com/kordlib/kord/tree/master/${project.name}/src/$name/kotlin/")
 
             remoteLineSuffix = "#L"
         }

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -12,12 +12,12 @@ tasks {
     test {
         useJUnitPlatform()
     }
+}
 
-    dokkaHtml {
-        configure()
-    }
+dokka {
+    configure(project)
 }
 
 mavenPublishing {
-    configure(KotlinJvm(JavadocJar.Dokka("dokkaHtml")))
+    configure(KotlinJvm(JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
 }

--- a/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/kord-publishing.gradle.kts
@@ -11,7 +11,6 @@ kord {
     metadataHost = Family.OSX
 }
 
-
 mavenPublishing {
     coordinates(Library.group, "cache-${project.name}")
     publishToMavenCentral()

--- a/buildSrc/src/main/kotlin/multiplatform-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiplatform-module.gradle.kts
@@ -70,7 +70,11 @@ tasks {
 }
 
 mavenPublishing {
-    configure(KotlinMultiplatform(JavadocJar.Dokka("dokkaHtml")))
+    configure(KotlinMultiplatform(JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
+}
+
+dokka {
+    configure(project)
 }
 
 apiValidation {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ nextPlannedVersion=0.6.0
 # 1) The only entity who needs to worry about these is the CI
 # 2) This way non MacOS users can check darwin code
 kotlin.native.ignoreDisabledTargets=true
-# https://youtrack.jetbrains.com/issue/KT-32476
-# https://github.com/Kotlin/kotlinx-atomicfu/issues/141#issuecomment-644621357
-kotlin.native.ignoreIncorrectDependencies=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
-coroutines = "1.8.1"
-stately = "2.0.7"
+coroutines = "1.9.0"
+stately = "2.1.0"
 kotlinx-atomicfu = "0.25.0"
-kotlin = "2.0.0"
-kotlin-serialization = "1.7.1"
-kotlinx-benchmark = "0.4.11"
+kotlin = "2.0.21"
+kotlin-serialization = "1.7.3"
+kotlinx-benchmark = "0.4.12"
 jmh = "1.37"
 
 [libraries]
-kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging", version = "6.0.9" }
-slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "2.0.13" }
+kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging", version = "7.0.0" }
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "2.0.16" }
 
 # implementations
 stately-collections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "stately" }
 stately-concurrency = { module = "co.touchlab:stately-concurrency", version.ref = "stately" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
-lettuce = { module = "io.lettuce:lettuce-core", version = "6.3.2.RELEASE" }
+lettuce = { module = "io.lettuce:lettuce-core", version = "6.4.0.RELEASE" }
 
 # tests
 kotlin-test-annotations = { group = "org.jetbrains.kotlin", name = "kotlin-test-annotations-common", version.ref = "kotlin" }
@@ -36,10 +36,10 @@ kotlinx-benchmark = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark
 # plugins
 atomicfu-plugin = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "kotlinx-atomicfu" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
-binary-compatibility-validator-plugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.15.0-Beta.2" }
-dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.28.0" }
-kord-gradle-plugin = { module = "dev.kord:gradle-tools", version = "1.6.0" }
+binary-compatibility-validator-plugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.16.3" }
+dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.0.0-Beta" }
+maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.30.0" }
+kord-gradle-plugin = { module = "dev.kord:gradle-tools", version = "1.7.1" }
 
 [bundles]
 stately = ["stately-collections", "stately-concurrency"]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Update Gradle to 8.10.2
- Update Kotlin 2.0.21
- Update kotlin-logging to 7.0.0
- Update slf4j-api to 2.0.16
- Update lettuce to 6.4.0.RELEASE
- Update kotlinx-binary-compatibility-validator to 0.16.3
- Update Dokka 2.0.0-Beta
- Update gradle-maven-publish-plugin to 0.30.0
- Update kord-gradle-tools to 1.7.1
- Update to Dokka v2 plugin